### PR TITLE
Fix: Double slash in R2 path construction causing 404 errors

### DIFF
--- a/cloudflare_worker/github_gitlab_r2_b2.js
+++ b/cloudflare_worker/github_gitlab_r2_b2.js
@@ -1006,8 +1006,8 @@ export default {
         const r2Requests = await Promise.all(R2_CONFIGS.map(async (r2Config) => {
           // 构建包含子目录的完整路径
           const storagePath = getStoragePath(`${subPath}/${FILE}`);
-          const r2Path = `${r2Config.bucket}/${DIR}/${storagePath}`;
-
+          // 检查 DIR 是否为空，如果为空则直接拼接 bucket 和 storagePath。
+          const r2Path = DIR ? `${r2Config.bucket}/${DIR}/${storagePath}` : `${r2Config.bucket}/${storagePath}`;
           const signedRequest = await getSignedUrl(r2Config, 'GET', r2Path);
           return {
             url: signedRequest.url,


### PR DESCRIPTION
Problem:
const r2Path = `${r2Config.bucket}/${DIR}/${storagePath}`;

当 DIR 为空时，生成的路径有双斜杠变成 bucket//subfolder/file.ext，这在 S3 兼容的 API 中被视为不同于 bucket/subfolder/file.ext 的路径，因此找不到文件。



Solution:
const r2Path = DIR ? `${r2Config.bucket}/${DIR}/${storagePath}` : `${r2Config.bucket}/${storagePath}`;

修改路径构建逻辑，增加处理dir为空的逻辑，如果为空则直接拼接 bucket 和 storagePath。